### PR TITLE
Implement blog post pages

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -1,0 +1,62 @@
+import Link from "next/link";
+import Image from "next/image";
+import { notFound } from "next/navigation";
+import { ArrowLeft, Calendar } from "lucide-react";
+import { blogPosts } from "../data";
+import { Button } from "@/components/ui/button";
+
+interface Params {
+  params: {
+    slug: string;
+  };
+}
+
+export default function BlogPostPage({ params }: Params) {
+  const post = blogPosts.find((p) => p.slug === params.slug);
+  if (!post) {
+    return notFound();
+  }
+
+  return (
+    <div className="pt-20">
+      <div className="bg-mint/30 py-12 dark:bg-accent/5 md:py-16 lg:py-20">
+        <div className="container mx-auto px-4">
+          <Button asChild variant="ghost" className="mb-6">
+            <Link href="/blog" className="flex items-center gap-2">
+              <ArrowLeft className="h-4 w-4" /> Назад к блогу
+            </Link>
+          </Button>
+          <h1 className="mb-2 font-playfair text-3xl font-bold md:text-4xl lg:text-5xl">
+            {post.title}
+          </h1>
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Calendar className="h-4 w-4" />
+            <span>{post.date}</span>
+            <span className="rounded-full bg-primary/10 px-2 py-0.5 text-xs text-primary-foreground">
+              {post.category}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div className="container mx-auto px-4 py-12">
+        <div className="prose mx-auto dark:prose-invert">
+          <Image
+            src={post.image}
+            alt={post.title}
+            width={800}
+            height={450}
+            className="mb-8 h-auto w-full rounded-lg object-cover"
+            placeholder="blur"
+            blurDataURL={post.blurDataUrl}
+          />
+          <p>{post.excerpt}</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function generateStaticParams() {
+  return blogPosts.map((post) => ({ slug: post.slug }));
+}

--- a/app/blog/data.ts
+++ b/app/blog/data.ts
@@ -1,0 +1,69 @@
+export const blogPosts = [
+  {
+    slug: "managing-anxiety-everyday-techniques",
+    title: "Управление тревогой: техники для повседневной жизни",
+    excerpt:
+      "Простые, но эффективные стратегии, которые помогут справиться с тревожностью в повседневных ситуациях.",
+    date: "10 мая 2023",
+    image: "https://images.pexels.com/photos/3560044/pexels-photo-3560044.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2",
+    blurDataUrl:
+      "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDABQODxIPDRQSEBIXFRQYHjIhHhwcHj0sLiQySUBMS0dARkVQWnNiUFVtVkVGZIhlbXd7gYKBTmCNl4x9lnN+gXz/2wBDARUXFx4aHjshITt8U0ZTfHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHz/wAARCAAIAAoDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAb/xAAeEAABBAIDAAAAAAAAAAAAAAABAAIDBAURIUFRYf/EABUBAQEAAAAAAAAAAAAAAAAAAAME/8QAFxEAAwEAAAAAAAAAAAAAAAAAAAECEf/aAAwDAQACEQMRAD8AsONxc2UtAGSey7d8oiJtGf/Z",
+    category: "Тревожность",
+  },
+  {
+    slug: "burnout-recovery-self-care",
+    title: "Восстановление после выгорания: практики самопомощи",
+    excerpt:
+      "Как распознать признаки выгорания и какие шаги предпринять для восстановления эмоционального баланса.",
+    date: "2 апреля 2023",
+    image: "https://images.pexels.com/photos/3771836/pexels-photo-3771836.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2",
+    blurDataUrl:
+      "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDABQODxIPDRQSEBIXFRQYHjIhHhwcHj0sLiQySUBMS0dARkVQWnNiUFVtVkVGZIhlbXd7gYKBTmCNl4x9lnN+gXz/2wBDARUXFx4aHjshITt8U0ZTfHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHz/wAARCAAIAAoDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAb/xAAdEAABBAMBAQAAAAAAAAAAAAABAAIDBBEhQVES/8QAFQEBAQAAAAAAAAAAAAAAAAAAAwT/xAAWEQEBAQAAAAAAAAAAAAAAAAABAAL/2gAMAwEAAhEDEQA/AJ7E1pCyGTlxGHDzuiiLFl//2Q==",
+    category: "Выгорание",
+  },
+  {
+    slug: "healthy-relationships-boundaries",
+    title: "Здоровые отношения: важность личных границ",
+    excerpt:
+      "Как устанавливать и поддерживать здоровые границы в отношениях с партнёром, семьёй и коллегами.",
+    date: "15 марта 2023",
+    image: "https://images.pexels.com/photos/5699466/pexels-photo-5699466.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2",
+    blurDataUrl:
+      "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDABQODxIPDRQSEBIXFRQYHjIhHhwcHj0sLiQySUBMS0dARkVQWnNiUFVtVkVGZIhlbXd7gYKBTmCNl4x9lnN+gXz/2wBDARUXFx4aHjshITt8U0ZTfHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHz/wAARCAAIAAoDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAb/xAAeEAABBAIDAAAAAAAAAAAAAAABAAIDBAURIUFRYf/EABUBAQEAAAAAAAAAAAAAAAAAAAME/8QAFxEAAwEAAAAAAAAAAAAAAAAAAAECEf/aAAwDAQACEQMRAD8AsONxc2UtAGSey7d8oiJtGf/Z",
+    category: "Отношения",
+  },
+  {
+    slug: "mindfulness-daily-practice",
+    title: "Майндфулнес в повседневной жизни: простые практики",
+    excerpt:
+      "Как интегрировать практики осознанности в повседневную жизнь для снижения стресса и повышения качества жизни.",
+    date: "28 февраля 2023",
+    image: "https://images.pexels.com/photos/1051838/pexels-photo-1051838.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2",
+    blurDataUrl:
+      "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDABQODxIPDRQSEBIXFRQYHjIhHhwcHj0sLiQySUBMS0dARkVQWnNiUFVtVkVGZIhlbXd7gYKBTmCNl4x9lnN+gXz/2wBDARUXFx4aHjshITt8U0ZTfHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHz/wAARCAAIAAoDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAb/xAAeEAABBAIDAAAAAAAAAAAAAAABAAIDBAURIUFRYf/EABUBAQEAAAAAAAAAAAAAAAAAAAME/8QAFxEAAwEAAAAAAAAAAAAAAAAAAAECEf/aAAwDAQACEQMRAD8AsONxc2UtAGSey7d8oiJtGf/Z",
+    category: "Практики",
+  },
+  {
+    slug: "depression-understanding-treatment",
+    title: "Депрессия: понимание и современные методы лечения",
+    excerpt:
+      "Что нужно знать о депрессии и какие подходы к лечению наиболее эффективны согласно современным исследованиям.",
+    date: "10 февраля 2023",
+    image: "https://images.pexels.com/photos/5699463/pexels-photo-5699463.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2",
+    blurDataUrl:
+      "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDABQODxIPDRQSEBIXFRQYHjIhHhwcHj0sLiQySUBMS0dARkVQWnNiUFVtVkVGZIhlbXd7gYKBTmCNl4x9lnN+gXz/2wBDARUXFx4aHjshITt8U0ZTfHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHz/wAARCAAIAAoDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAb/xAAeEAABBAIDAAAAAAAAAAAAAAABAAIDBAURIUFRYf/EABUBAQEAAAAAAAAAAAAAAAAAAAME/8QAFxEAAwEAAAAAAAAAAAAAAAAAAAECEf/aAAwDAQACEQMRAD8AsONxc2UtAGSey7d8oiJtGf/Z",
+    category: "Депрессия",
+  },
+  {
+    slug: "self-esteem-building-strategies",
+    title: "Стратегии повышения самооценки и уверенности в себе",
+    excerpt:
+      "Практические упражнения и методики для развития здоровой самооценки и преодоления внутреннего критика.",
+    date: "15 января 2023",
+    image: "https://images.pexels.com/photos/5699456/pexels-photo-5699456.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2",
+    blurDataUrl:
+      "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDABQODxIPDRQSEBIXFRQYHjIhHhwcHj0sLiQySUBMS0dARkVQWnNiUFVtVkVGZIhlbXd7gYKBTmCNl4x9lnN+gXz/2wBDARUXFx4aHjshITt8U0ZTfHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHz/wAARCAAIAAoDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAb/xAAeEAABBAIDAAAAAAAAAAAAAAABAAIDBAURIUFRYf/EABUBAQEAAAAAAAAAAAAAAAAAAAME/8QAFxEAAwEAAAAAAAAAAAAAAAAAAAECEf/aAAwDAQACEQMRAD8AsONxc2UtAGSey7d8oiJtGf/Z",
+    category: "Самооценка",
+  },
+] as const;
+export type BlogPost = (typeof blogPosts)[number];

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -4,63 +4,9 @@ import { Button } from "@/components/ui/button";
 import { ArrowRight, Calendar } from "lucide-react";
 import { Card, CardContent, CardFooter, CardHeader } from "@/components/ui/card";
 
+import { blogPosts } from "./data";
+
 // This would typically come from a CMS or database
-const blogPosts = [
-  {
-    slug: "managing-anxiety-everyday-techniques",
-    title: "Управление тревогой: техники для повседневной жизни",
-    excerpt: "Простые, но эффективные стратегии, которые помогут справиться с тревожностью в повседневных ситуациях.",
-    date: "10 мая 2023",
-    image: "https://images.pexels.com/photos/3560044/pexels-photo-3560044.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2",
-    blurDataUrl: "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDABQODxIPDRQSEBIXFRQYHjIhHhwcHj0sLiQySUBMS0dARkVQWnNiUFVtVkVGZIhlbXd7gYKBTmCNl4x9lnN+gXz/2wBDARUXFx4aHjshITt8U0ZTfHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHz/wAARCAAIAAoDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAb/xAAeEAABBAIDAQAAAAAAAAAAAAABAAIDBAURIUFRYf/EABUBAQEAAAAAAAAAAAAAAAAAAAME/8QAFxEAAwEAAAAAAAAAAAAAAAAAAAECEf/aAAwDAQACEQMRAD8AsONxc2UtAGSey7d8oiJtGf/Z",
-    category: "Тревожность",
-  },
-  {
-    slug: "burnout-recovery-self-care",
-    title: "Восстановление после выгорания: практики самопомощи",
-    excerpt: "Как распознать признаки выгорания и какие шаги предпринять для восстановления эмоционального баланса.",
-    date: "2 апреля 2023",
-    image: "https://images.pexels.com/photos/3771836/pexels-photo-3771836.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2",
-    blurDataUrl: "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDABQODxIPDRQSEBIXFRQYHjIhHhwcHj0sLiQySUBMS0dARkVQWnNiUFVtVkVGZIhlbXd7gYKBTmCNl4x9lnN+gXz/2wBDARUXFx4aHjshITt8U0ZTfHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHz/wAARCAAIAAoDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAb/xAAdEAABBAMBAQAAAAAAAAAAAAABAAIDBBEhQVES/8QAFQEBAQAAAAAAAAAAAAAAAAAAAwT/xAAWEQEBAQAAAAAAAAAAAAAAAAABAAL/2gAMAwEAAhEDEQA/AJ7E1pCyGTlxGHDzuiiLFl//2Q==",
-    category: "Выгорание",
-  },
-  {
-    slug: "healthy-relationships-boundaries",
-    title: "Здоровые отношения: важность личных границ",
-    excerpt: "Как устанавливать и поддерживать здоровые границы в отношениях с партнёром, семьёй и коллегами.",
-    date: "15 марта 2023",
-    image: "https://images.pexels.com/photos/5699466/pexels-photo-5699466.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2",
-    blurDataUrl: "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDABQODxIPDRQSEBIXFRQYHjIhHhwcHj0sLiQySUBMS0dARkVQWnNiUFVtVkVGZIhlbXd7gYKBTmCNl4x9lnN+gXz/2wBDARUXFx4aHjshITt8U0ZTfHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHz/wAARCAAIAAoDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAb/xAAeEAABBAIDAQAAAAAAAAAAAAABAAIDBAURIUFRYf/EABUBAQEAAAAAAAAAAAAAAAAAAAME/8QAFxEAAwEAAAAAAAAAAAAAAAAAAAECEf/aAAwDAQACEQMRAD8AsONxc2UtAGSey7d8oiJtGf/Z",
-    category: "Отношения",
-  },
-  {
-    slug: "mindfulness-daily-practice",
-    title: "Майндфулнес в повседневной жизни: простые практики",
-    excerpt: "Как интегрировать практики осознанности в повседневную жизнь для снижения стресса и повышения качества жизни.",
-    date: "28 февраля 2023",
-    image: "https://images.pexels.com/photos/1051838/pexels-photo-1051838.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2",
-    blurDataUrl: "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDABQODxIPDRQSEBIXFRQYHjIhHhwcHj0sLiQySUBMS0dARkVQWnNiUFVtVkVGZIhlbXd7gYKBTmCNl4x9lnN+gXz/2wBDARUXFx4aHjshITt8U0ZTfHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHz/wAARCAAIAAoDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAb/xAAeEAABBAIDAQAAAAAAAAAAAAABAAIDBAURIUFRYf/EABUBAQEAAAAAAAAAAAAAAAAAAAME/8QAFxEAAwEAAAAAAAAAAAAAAAAAAAECEf/aAAwDAQACEQMRAD8AsONxc2UtAGSey7d8oiJtGf/Z",
-    category: "Практики",
-  },
-  {
-    slug: "depression-understanding-treatment",
-    title: "Депрессия: понимание и современные методы лечения",
-    excerpt: "Что нужно знать о депрессии и какие подходы к лечению наиболее эффективны согласно современным исследованиям.",
-    date: "10 февраля 2023",
-    image: "https://images.pexels.com/photos/5699463/pexels-photo-5699463.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2",
-    blurDataUrl: "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDABQODxIPDRQSEBIXFRQYHjIhHhwcHj0sLiQySUBMS0dARkVQWnNiUFVtVkVGZIhlbXd7gYKBTmCNl4x9lnN+gXz/2wBDARUXFx4aHjshITt8U0ZTfHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHz/wAARCAAIAAoDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAb/xAAeEAABBAIDAQAAAAAAAAAAAAABAAIDBAURIUFRYf/EABUBAQEAAAAAAAAAAAAAAAAAAAME/8QAFxEAAwEAAAAAAAAAAAAAAAAAAAECEf/aAAwDAQACEQMRAD8AsONxc2UtAGSey7d8oiJtGf/Z",
-    category: "Депрессия",
-  },
-  {
-    slug: "self-esteem-building-strategies",
-    title: "Стратегии повышения самооценки и уверенности в себе",
-    excerpt: "Практические упражнения и методики для развития здоровой самооценки и преодоления внутреннего критика.",
-    date: "15 января 2023",
-    image: "https://images.pexels.com/photos/5699456/pexels-photo-5699456.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2",
-    blurDataUrl: "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDABQODxIPDRQSEBIXFRQYHjIhHhwcHj0sLiQySUBMS0dARkVQWnNiUFVtVkVGZIhlbXd7gYKBTmCNl4x9lnN+gXz/2wBDARUXFx4aHjshITt8U0ZTfHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHz/wAARCAAIAAoDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAb/xAAeEAABBAIDAQAAAAAAAAAAAAABAAIDBAURIUFRYf/EABUBAQEAAAAAAAAAAAAAAAAAAAME/8QAFxEAAwEAAAAAAAAAAAAAAAAAAAECEf/aAAwDAQACEQMRAD8AsONxc2UtAGSey7d8oiJtGf/Z",
-    category: "Самооценка",
-  },
-];
 
 export default function BlogPage() {
   return (


### PR DESCRIPTION
## Summary
- store blog posts in a shared data file
- use the data in the blog listing page
- add dynamic `[slug]` page to show individual posts

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841afe875c0832483b006108a044ead